### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -825,7 +825,7 @@ services:
 
   consul:
     hostname: consul
-    image: consul:latest
+    image: hashicorp/consul:latest
     restart: always
     ports:
       - 8500:8500


### PR DESCRIPTION
Corrected image name


(https://hub.docker.com/_/consul)
DEPRECATION NOTICE
Upcoming in Consul 1.16, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from hashicorp/consul instead of consul. Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/consul.